### PR TITLE
Use MediatorLiveData and ConnectionLiveData instead of non public api

### DIFF
--- a/app/src/main/java/com/danielecampogiani/retry/ViewModelExtensions.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/ViewModelExtensions.kt
@@ -23,5 +23,4 @@ fun <T> ViewModel.launchWithRetry(
             onNoNetwork()
         }
     }
-
 }

--- a/app/src/main/java/com/danielecampogiani/retry/ViewModelExtensions.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/ViewModelExtensions.kt
@@ -1,38 +1,27 @@
 package androidx.lifecycle
 
-import com.danielecampogiani.retry.connection.ConnectionChecker
+import com.danielecampogiani.retry.connection.ConnectionLiveData
 import kotlinx.coroutines.launch
-import java.io.Closeable
 
 fun <T> ViewModel.launchWithRetry(
+    mediatorLiveData: MediatorLiveData<*>,
     networkOperation: suspend () -> T,
     loading: () -> Unit,
     resultConsumer: (T) -> Unit,
     onNoNetwork: () -> Unit,
-    connectionChecker: ConnectionChecker
+    connectionLiveData: ConnectionLiveData
 ) {
-
-    if (connectionChecker.isConnected) {
+    mediatorLiveData.addSource(connectionLiveData) { hasConnection ->
         loading()
-        viewModelScope.launch {
-            val networkData = networkOperation()
-            resultConsumer(networkData)
-        }
-    } else {
-        onNoNetwork()
-        val listener = object : ConnectionChecker.Listener {
-            override fun onConnected() {
-                connectionChecker.removeListener(this)
-                launchWithRetry(networkOperation, loading, resultConsumer, onNoNetwork, connectionChecker)
+        if (hasConnection) {
+            viewModelScope.launch {
+                val networkData = networkOperation()
+                resultConsumer(networkData)
             }
+
+        } else {
+            onNoNetwork()
         }
-        connectionChecker.addListener(listener)
-        val listenerHashCode = listener.hashCode().toString()
-        setTagIfAbsent(listenerHashCode, object : Closeable {
-            override fun close() {
-                connectionChecker.removeListener(listener)
-            }
-        })
     }
 
 }

--- a/app/src/main/java/com/danielecampogiani/retry/connection/ConnectionChecker.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/connection/ConnectionChecker.kt
@@ -9,6 +9,6 @@ interface ConnectionChecker {
     fun removeListener(listener: Listener)
 
     interface Listener {
-        fun onConnected()
+        fun onConnectionChanged(hasConnection: Boolean)
     }
 }

--- a/app/src/main/java/com/danielecampogiani/retry/connection/ConnectionCheckerImpl.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/connection/ConnectionCheckerImpl.kt
@@ -32,11 +32,11 @@ class ConnectionCheckerImpl @Inject constructor(
     }
 
     private fun onNetworkChanged() {
-        if (isConnected) {
-            listeners.forEach {
-                it.onConnected()
-            }
+        val connected = isConnected
+        listeners.forEach {
+            it.onConnectionChanged(connected)
         }
+
     }
 
     override val isConnected: Boolean

--- a/app/src/main/java/com/danielecampogiani/retry/connection/ConnectionLiveData.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/connection/ConnectionLiveData.kt
@@ -1,0 +1,24 @@
+package com.danielecampogiani.retry.connection
+
+import androidx.lifecycle.LiveData
+import javax.inject.Inject
+
+class ConnectionLiveData @Inject constructor(
+    private val connectionChecker: ConnectionChecker
+) : LiveData<Boolean>() {
+
+    private val listener = object : ConnectionChecker.Listener {
+        override fun onConnectionChanged(hasConnection: Boolean) {
+            value = hasConnection
+        }
+
+    }
+
+    override fun onActive() {
+        connectionChecker.addListener(listener)
+    }
+
+    override fun onInactive() {
+        connectionChecker.removeListener(listener)
+    }
+}

--- a/app/src/main/java/com/danielecampogiani/retry/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/detail/DetailViewModel.kt
@@ -1,35 +1,45 @@
 package com.danielecampogiani.retry.detail
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.launchWithRetry
 import com.danielecampogiani.retry.R
-import com.danielecampogiani.retry.connection.ConnectionChecker
+import com.danielecampogiani.retry.connection.ConnectionLiveData
 import javax.inject.Inject
 
 class DetailViewModel @Inject constructor(
-    private val connectionChecker: ConnectionChecker,
-    private val service: DetailService
+    private val service: DetailService,
+    connectionLiveData: ConnectionLiveData
 ) : ViewModel() {
 
-    private val mutableState = MutableLiveData<DetailState>()
-
+    private val mutableState = MediatorLiveData<DetailState>()
     val state: LiveData<DetailState>
         get() = mutableState
 
 
     init {
-        load()
-    }
+        /*mutableState.addSource(connectionLiveData) { hasConnection ->
+            mutableState.value = DetailState.Loading
+            if (hasConnection) {
+                viewModelScope.launch {
+                    val data = service.loadData()
+                    mutableState.value = DetailState.Result(data)
+                }
+            } else {
+                mutableState.value = DetailState.Error(R.string.no_network_message)
+            }
+        }*/
 
-    private fun load() {
         launchWithRetry(
+            mediatorLiveData = mutableState,
             networkOperation = { service.loadData() },
-            resultConsumer = { mutableState.value = DetailState.Result(it) },
             loading = { mutableState.value = DetailState.Loading },
+            resultConsumer = { mutableState.value = DetailState.Result(it) },
             onNoNetwork = { mutableState.value = DetailState.Error(R.string.no_network_message) },
-            connectionChecker = connectionChecker
+            connectionLiveData = connectionLiveData
         )
     }
+
+
 }

--- a/app/src/main/java/com/danielecampogiani/retry/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/detail/DetailViewModel.kt
@@ -19,18 +19,6 @@ class DetailViewModel @Inject constructor(
 
 
     init {
-        /*mutableState.addSource(connectionLiveData) { hasConnection ->
-            mutableState.value = DetailState.Loading
-            if (hasConnection) {
-                viewModelScope.launch {
-                    val data = service.loadData()
-                    mutableState.value = DetailState.Result(data)
-                }
-            } else {
-                mutableState.value = DetailState.Error(R.string.no_network_message)
-            }
-        }*/
-
         launchWithRetry(
             mediatorLiveData = mutableState,
             networkOperation = { service.loadData() },

--- a/app/src/main/java/com/danielecampogiani/retry/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/danielecampogiani/retry/detail/DetailViewModel.kt
@@ -28,6 +28,4 @@ class DetailViewModel @Inject constructor(
             connectionLiveData = connectionLiveData
         )
     }
-
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 18 18:18:19 CEST 2019
+#Sat Aug 31 18:08:57 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip


### PR DESCRIPTION
- Create a custom LiveData to observe connectivity changes (ConnectionLiveData).
- In ViewModel react to ConnectionLiveData scheduling network operation or displaying message according to received data